### PR TITLE
Refactored ore worldgen config

### DIFF
--- a/src/main/java/tech/flatstone/appliedlogistics/AppliedLogistics.java
+++ b/src/main/java/tech/flatstone/appliedlogistics/AppliedLogistics.java
@@ -20,23 +20,22 @@
 
 package tech.flatstone.appliedlogistics;
 
-import net.minecraft.block.state.IBlockState;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
 import tech.flatstone.appliedlogistics.api.exceptions.OutdatedJavaException;
-import tech.flatstone.appliedlogistics.api.features.EnumOreType;
-import tech.flatstone.appliedlogistics.common.blocks.Blocks;
+import tech.flatstone.appliedlogistics.common.config.Config;
 import tech.flatstone.appliedlogistics.common.integrations.IntegrationsManager;
 import tech.flatstone.appliedlogistics.common.network.PacketHandler;
-import tech.flatstone.appliedlogistics.common.util.EnumOres;
 import tech.flatstone.appliedlogistics.common.world.WorldGen;
 import tech.flatstone.appliedlogistics.proxy.IProxy;
 
@@ -93,6 +92,8 @@ public class AppliedLogistics {
         GameRegistry.registerWorldGenerator(worldGen, 0);
         MinecraftForge.EVENT_BUS.register(worldGen);
 
+        MinecraftForge.EVENT_BUS.register(this);
+
         // Init Integrations
         IntegrationsManager.instance().init();
     }
@@ -100,5 +101,12 @@ public class AppliedLogistics {
     @Mod.EventHandler
     public void postInit(FMLPostInitializationEvent event) {
         IntegrationsManager.instance().postInit();
+    }
+
+    @SubscribeEvent
+    public void onConfigurationChangedEvent(ConfigChangedEvent.OnConfigChangedEvent event) {
+        if (event.modID == ModInfo.MOD_ID) {
+            Config.loadConfiguration();
+        }
     }
 }

--- a/src/main/java/tech/flatstone/appliedlogistics/AppliedLogistics.java
+++ b/src/main/java/tech/flatstone/appliedlogistics/AppliedLogistics.java
@@ -105,7 +105,7 @@ public class AppliedLogistics {
 
     @SubscribeEvent
     public void onConfigurationChangedEvent(ConfigChangedEvent.OnConfigChangedEvent event) {
-        if (event.modID == ModInfo.MOD_ID) {
+        if (event.modID.equals(ModInfo.MOD_ID)) {
             Config.loadConfiguration();
         }
     }

--- a/src/main/java/tech/flatstone/appliedlogistics/common/config/Config.java
+++ b/src/main/java/tech/flatstone/appliedlogistics/common/config/Config.java
@@ -5,8 +5,6 @@ import net.minecraftforge.common.config.ConfigElement;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fml.client.config.GuiConfig;
 import net.minecraftforge.fml.client.config.IConfigElement;
-import net.minecraftforge.fml.client.event.ConfigChangedEvent;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import tech.flatstone.appliedlogistics.AppliedLogistics;
 import tech.flatstone.appliedlogistics.ModInfo;
 
@@ -17,12 +15,13 @@ public class Config extends GuiConfig {
     public static final String CONFIG_WORLDGEN = "worldgen";
 
     public Config(GuiScreen parentScreen) {
-        super (parentScreen,
-                Arrays.asList(new IConfigElement[] {
-                        new ConfigElement(AppliedLogistics.configuration.getCategory(CONFIG_WORLDGEN)),
-                }),
-                ModInfo.MOD_ID, false, false, "Applied Logistics Configuration");
-
+        super(
+            parentScreen,
+            Arrays.asList(new IConfigElement[]{
+                new ConfigElement(AppliedLogistics.configuration.getCategory(CONFIG_WORLDGEN)),
+            }),
+            ModInfo.MOD_ID, false, false, "Applied Logistics Configuration");
+        titleLine2 = AppliedLogistics.configuration.getConfigFile().getAbsolutePath();
     }
 
     public static Configuration configuration;
@@ -39,10 +38,5 @@ public class Config extends GuiConfig {
         ConfigWorldGen.init(configuration);
 
         configuration.save();
-    }
-
-    @SubscribeEvent
-    public void onConfigurationChangedEvent(ConfigChangedEvent.OnConfigChangedEvent event) {
-        loadConfiguration();
     }
 }

--- a/src/main/java/tech/flatstone/appliedlogistics/common/config/ConfigWorldGen.java
+++ b/src/main/java/tech/flatstone/appliedlogistics/common/config/ConfigWorldGen.java
@@ -111,7 +111,7 @@ public class ConfigWorldGen {
 
     public static void init(Configuration configuration) {
         configuration.setCategoryLanguageKey(Config.CONFIG_WORLDGEN, "config.worldGen");
-        configuration.setCategoryRequiresWorldRestart(Config.CONFIG_WORLDGEN, true);
+        configuration.setCategoryRequiresWorldRestart(Config.CONFIG_WORLDGEN, true); //TODO: This could theoretically be false now, if desired
 
         final String WORLDGEN_ORES = String.format("%s.%s", Config.CONFIG_WORLDGEN, "ores");
 
@@ -130,7 +130,14 @@ public class ConfigWorldGen {
             String category = String.format("%s.%s", WORLDGEN_ORES, oreName);
             OreConfig defaultConfig = OreWorldGenDefaults.get(ore);
 
-            OreConfig oreConfig = new OreConfig();
+            OreConfig oreConfig;
+            if (OreWorldGen.containsKey(ore)) {
+                // Manipulating the existing config will automatically update WorldGen
+                oreConfig = OreWorldGen.get(ore);
+            }
+            else {
+                oreConfig = new OreConfig();
+            }
 
             oreConfig.Enabled = ConfigHelper.getBoolean(configuration, oreName, WORLDGEN_ORES, defaultConfig.Enabled, String.format(DESC_ENABLED, oreLower));
 

--- a/src/main/java/tech/flatstone/appliedlogistics/common/config/ConfigWorldGen.java
+++ b/src/main/java/tech/flatstone/appliedlogistics/common/config/ConfigWorldGen.java
@@ -1,131 +1,152 @@
 package tech.flatstone.appliedlogistics.common.config;
 
 import net.minecraftforge.common.config.Configuration;
+import tech.flatstone.appliedlogistics.api.features.EnumOreType;
 import tech.flatstone.appliedlogistics.common.util.ConfigHelper;
+import tech.flatstone.appliedlogistics.common.util.EnumOres;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ConfigWorldGen {
-    public static boolean worldGen_Generate_Copper;
-    public static boolean worldGen_Generate_Tin;
-    public static boolean worldGen_Generate_Silver;
-    public static boolean worldGen_Generate_Lead;
-    public static boolean worldGen_Generate_Nickel;
-    public static boolean worldGen_Generate_Rutile;
-    
-    public static int worldGen_Generate_Copper_minY;
-    public static int worldGen_Generate_Copper_maxY;
-    public static int worldGen_Generate_Copper_veinSize;
-    public static int worldGen_Generate_Copper_weight;
-    public static int worldGen_Generate_Copper_chunkOccurrence;
-    public static String worldGen_Generate_Copper_dimensionRestriction;
-    public static int[] worldGen_Generate_Copper_dimensions;
+    public enum RestrictionType {
+        Blacklist,
+        Whitelist
+        ;
 
-    public static int worldGen_Generate_Tin_minY;
-    public static int worldGen_Generate_Tin_maxY;
-    public static int worldGen_Generate_Tin_veinSize;
-    public static int worldGen_Generate_Tin_weight;
-    public static int worldGen_Generate_Tin_chunkOccurrence;
-    public static String worldGen_Generate_Tin_dimensionRestriction;
-    public static int[] worldGen_Generate_Tin_dimensions;
+        public static RestrictionType fromString(String str, RestrictionType def) {
+            for (RestrictionType rt : values()) {
+                if (rt.name().equalsIgnoreCase(str)) {
+                    return rt;
+                }
+            }
 
-    public static int worldGen_Generate_Silver_minY;
-    public static int worldGen_Generate_Silver_maxY;
-    public static int worldGen_Generate_Silver_veinSize;
-    public static int worldGen_Generate_Silver_weight;
-    public static int worldGen_Generate_Silver_chunkOccurrence;
-    public static String worldGen_Generate_Silver_dimensionRestriction;
-    public static int[] worldGen_Generate_Silver_dimensions;
+            return def;
+        }
+    }
 
-    public static int worldGen_Generate_Lead_minY;
-    public static int worldGen_Generate_Lead_maxY;
-    public static int worldGen_Generate_Lead_veinSize;
-    public static int worldGen_Generate_Lead_weight;
-    public static int worldGen_Generate_Lead_chunkOccurrence;
-    public static String worldGen_Generate_Lead_dimensionRestriction;
-    public static int[] worldGen_Generate_Lead_dimensions;
+    public static class OreConfig {
+        public boolean Enabled;
+        public int MinY;
+        public int MaxY;
+        public int VeinSize;
+        public int Weight;
+        public int ChunkOccurrence;
+        public RestrictionType DimensionRestriction;
+        public int[] Dimensions;
 
-    public static int worldGen_Generate_Nickel_minY;
-    public static int worldGen_Generate_Nickel_maxY;
-    public static int worldGen_Generate_Nickel_veinSize;
-    public static int worldGen_Generate_Nickel_weight;
-    public static int worldGen_Generate_Nickel_chunkOccurrence;
-    public static String worldGen_Generate_Nickel_dimensionRestriction;
-    public static int[] worldGen_Generate_Nickel_dimensions;
+        public boolean isEnabledForDim(int dim) {
+            boolean inList = false;
+            for (int listDim : Dimensions)
+                inList = inList || listDim == dim;
+            return (inList && DimensionRestriction == RestrictionType.Whitelist) ||
+                   (!inList && DimensionRestriction == RestrictionType.Blacklist);
+        }
+    }
 
-    public static int worldGen_Generate_Rutile_minY;
-    public static int worldGen_Generate_Rutile_maxY;
-    public static int worldGen_Generate_Rutile_veinSize;
-    public static int worldGen_Generate_Rutile_weight;
-    public static int worldGen_Generate_Rutile_chunkOccurrence;
-    public static String worldGen_Generate_Rutile_dimensionRestriction;
-    public static int[] worldGen_Generate_Rutile_dimensions;
+    public static final Map<EnumOres, OreConfig> OreWorldGen = new HashMap<>(EnumOres.values().length);
+
+    private static final Map<EnumOres, OreConfig> OreWorldGenDefaults = new HashMap<>(EnumOres.values().length);
+
+    private static final int[] DEFAULT_DIMENSION_BLACKLIST = {-1, 1};
+
+    static {
+        // Initialize defaults
+        for (EnumOres ore : EnumOres.byType(EnumOreType.ORE)) {
+            OreConfig defaultConfig = new OreConfig();
+            defaultConfig.Enabled = true;
+            defaultConfig.DimensionRestriction = RestrictionType.Blacklist;
+            defaultConfig.Dimensions = DEFAULT_DIMENSION_BLACKLIST;
+
+            // Might want to vary this per-ore at some point, but so far it's constant
+            defaultConfig.ChunkOccurrence = 20;
+
+            switch (ore) {
+                case COPPER:
+                    defaultConfig.MinY = 10;
+                    defaultConfig.MaxY = 75;
+                    defaultConfig.VeinSize = 16;
+                    defaultConfig.Weight = 40;
+                    break;
+
+                case TIN:
+                    defaultConfig.MinY = 20;
+                    defaultConfig.MaxY = 55;
+                    defaultConfig.VeinSize = 10;
+                    defaultConfig.Weight = 40;
+                    break;
+
+                case SILVER:
+                    defaultConfig.MinY = 5;
+                    defaultConfig.MaxY = 30;
+                    defaultConfig.VeinSize = 8;
+                    defaultConfig.Weight = 20;
+                    break;
+
+                case LEAD:
+                    defaultConfig.MinY = 10;
+                    defaultConfig.MaxY = 35;
+                    defaultConfig.VeinSize = 8;
+                    defaultConfig.Weight = 20;
+                    break;
+
+                case NICKEL:
+                    defaultConfig.MinY = 5;
+                    defaultConfig.MaxY = 60;
+                    defaultConfig.VeinSize = 4;
+                    defaultConfig.Weight = 20;
+                    break;
+
+                case RUTILE:
+                    defaultConfig.MinY = 1;
+                    defaultConfig.MaxY = 75;
+                    defaultConfig.VeinSize = 20;
+                    defaultConfig.Weight = 30;
+                    break;
+            }
+
+            OreWorldGenDefaults.put(ore, defaultConfig);
+        }
+    }
 
     public static void init(Configuration configuration) {
         configuration.setCategoryLanguageKey(Config.CONFIG_WORLDGEN, "config.worldGen");
         configuration.setCategoryRequiresWorldRestart(Config.CONFIG_WORLDGEN, true);
 
-        int[] dimBlacklist = {-1, 1};
-        
         final String WORLDGEN_ORES = String.format("%s.%s", Config.CONFIG_WORLDGEN, "ores");
-        final String WORLDGEN_ORES_COPPER = String.format("%s.%s", WORLDGEN_ORES, "Copper");
-        final String WORLDGEN_ORES_TIN = String.format("%s.%s", WORLDGEN_ORES, "Tin");
-        final String WORLDGEN_ORES_SILVER = String.format("%s.%s", WORLDGEN_ORES, "Silver");
-        final String WORLDGEN_ORES_LEAD = String.format("%s.%s", WORLDGEN_ORES, "Lead");
-        final String WORLDGEN_ORES_NICKEL = String.format("%s.%s", WORLDGEN_ORES, "Nickel");
-        final String WORLDGEN_ORES_RUTILE = String.format("%s.%s", WORLDGEN_ORES, "Rutile");
-        
-        worldGen_Generate_Copper = ConfigHelper.getBoolean(configuration, "Copper", WORLDGEN_ORES, true, "Enable copper in world generation");
-        worldGen_Generate_Tin = ConfigHelper.getBoolean(configuration, "Tin", WORLDGEN_ORES, true, "Enable tin in world generation");
-        worldGen_Generate_Silver = ConfigHelper.getBoolean(configuration, "Silver", WORLDGEN_ORES, true, "Enable silver in world generation");
-        worldGen_Generate_Lead = ConfigHelper.getBoolean(configuration, "Lead", WORLDGEN_ORES, true, "Enable lead in world generation");
-        worldGen_Generate_Nickel = ConfigHelper.getBoolean(configuration, "Nickel", WORLDGEN_ORES, true, "Enable nickel in world generation");
-        worldGen_Generate_Rutile = ConfigHelper.getBoolean(configuration, "Rutile", WORLDGEN_ORES, true, "Enable rutile in world generation");
 
-        worldGen_Generate_Copper_minY = ConfigHelper.getInteger(configuration, "Min Height", WORLDGEN_ORES_COPPER, 10, "Min Y level copper will spawn at");
-        worldGen_Generate_Copper_maxY = ConfigHelper.getInteger(configuration, "Max Height", WORLDGEN_ORES_COPPER, 75, "Max Y level copper will spawn at");
-        worldGen_Generate_Copper_veinSize = ConfigHelper.getInteger(configuration, "Vein Size", WORLDGEN_ORES_COPPER, 16, "Size of vein");
-        worldGen_Generate_Copper_weight = ConfigHelper.getInteger(configuration, "Weight", WORLDGEN_ORES_COPPER, 40, "Percent chance that copper will generate in chunk");
-        worldGen_Generate_Copper_chunkOccurrence = ConfigHelper.getInteger(configuration, "Chunk Occurrence", WORLDGEN_ORES_COPPER, 20, "Number of times copper will attempt to generate in a chunk");
-        worldGen_Generate_Copper_dimensionRestriction = ConfigHelper.getString(configuration, "Dimension Restriction", WORLDGEN_ORES_COPPER, "blacklist", "Either 'blacklist' or 'whitelist'");
-        worldGen_Generate_Copper_dimensions = ConfigHelper.getIntegerList(configuration, "Dimensions", WORLDGEN_ORES_COPPER, dimBlacklist, "Dimension Numbers");
+        final String DESC_ENABLED = "Enable %s in world generation";
+        final String DESC_MIN_Y = "Minimum Y-level that %s will spawn at";
+        final String DESC_MAX_Y = "Maximum Y-level that %s will spawn at";
+        final String DESC_VEIN_SIZE = "Size of %s veins";
+        final String DESC_WEIGHT = "Percent chance that %s will generate for each chunk occurrence";
+        final String DESC_CHUNK_OCCURRENCE = "Number of times that %s will attempt to generate in each chunk";
+        final String DESC_DIM_RESTRICTION = "Either 'blacklist' or 'whitelist'";
+        final String DESC_DIM_LIST = "Dimension numbers for restriction";
 
-        worldGen_Generate_Tin_minY = ConfigHelper.getInteger(configuration, "Min Height", WORLDGEN_ORES_TIN, 20, "Min Y level tin will spawn at");
-        worldGen_Generate_Tin_maxY = ConfigHelper.getInteger(configuration, "Max Height", WORLDGEN_ORES_TIN, 55, "Max Y level tin will spawn at");
-        worldGen_Generate_Tin_veinSize = ConfigHelper.getInteger(configuration, "Vein Size", WORLDGEN_ORES_TIN, 10, "Size of vein");
-        worldGen_Generate_Tin_weight = ConfigHelper.getInteger(configuration, "Weight", WORLDGEN_ORES_TIN, 40, "Percent chance that tin will generate in chunk");
-        worldGen_Generate_Tin_chunkOccurrence = ConfigHelper.getInteger(configuration, "Chunk Occurrence", WORLDGEN_ORES_TIN, 20, "Number of times tin will attempt to generate in a chunk");
-        worldGen_Generate_Tin_dimensionRestriction = ConfigHelper.getString(configuration, "Dimension Restriction", WORLDGEN_ORES_TIN, "blacklist", "Either 'blacklist' or 'whitelist'");
-        worldGen_Generate_Tin_dimensions = ConfigHelper.getIntegerList(configuration, "Dimensions", WORLDGEN_ORES_TIN, dimBlacklist, "Dimension Numbers");
+        for (EnumOres ore : EnumOres.byType(EnumOreType.ORE)) {
+            String oreName = ore.getName();
+            String oreLower = oreName.toLowerCase();
+            String category = String.format("%s.%s", WORLDGEN_ORES, oreName);
+            OreConfig defaultConfig = OreWorldGenDefaults.get(ore);
 
-        worldGen_Generate_Silver_minY = ConfigHelper.getInteger(configuration, "Min Height", WORLDGEN_ORES_SILVER, 5, "Min Y level silver will spawn at");
-        worldGen_Generate_Silver_maxY = ConfigHelper.getInteger(configuration, "Max Height", WORLDGEN_ORES_SILVER, 30, "Max Y level silver will spawn at");
-        worldGen_Generate_Silver_veinSize = ConfigHelper.getInteger(configuration, "Vein Size", WORLDGEN_ORES_SILVER, 8, "Size of vein");
-        worldGen_Generate_Silver_weight = ConfigHelper.getInteger(configuration, "Weight", WORLDGEN_ORES_SILVER, 20, "Percent chance that silver will generate in chunk");
-        worldGen_Generate_Silver_chunkOccurrence = ConfigHelper.getInteger(configuration, "Chunk Occurrence", WORLDGEN_ORES_SILVER, 20, "Number of times silver will attempt to generate in a chunk");
-        worldGen_Generate_Silver_dimensionRestriction = ConfigHelper.getString(configuration, "Dimension Restriction", WORLDGEN_ORES_SILVER, "blacklist", "Either 'blacklist' or 'whitelist'");
-        worldGen_Generate_Silver_dimensions = ConfigHelper.getIntegerList(configuration, "Dimensions", WORLDGEN_ORES_SILVER, dimBlacklist, "Dimension Numbers");
+            OreConfig oreConfig = new OreConfig();
 
-        worldGen_Generate_Lead_minY = ConfigHelper.getInteger(configuration, "Min Height", WORLDGEN_ORES_LEAD, 10, "Min Y level lead will spawn at");
-        worldGen_Generate_Lead_maxY = ConfigHelper.getInteger(configuration, "Max Height", WORLDGEN_ORES_LEAD, 35, "Max Y level lead will spawn at");
-        worldGen_Generate_Lead_veinSize = ConfigHelper.getInteger(configuration, "Vein Size", WORLDGEN_ORES_LEAD, 8, "Size of vein");
-        worldGen_Generate_Lead_weight = ConfigHelper.getInteger(configuration, "Weight", WORLDGEN_ORES_LEAD, 20, "Percent chance that lead will generate in chunk");
-        worldGen_Generate_Lead_chunkOccurrence = ConfigHelper.getInteger(configuration, "Chunk Occurrence", WORLDGEN_ORES_LEAD, 20, "Number of times lead will attempt to generate in a chunk");
-        worldGen_Generate_Lead_dimensionRestriction = ConfigHelper.getString(configuration, "Dimension Restriction", WORLDGEN_ORES_LEAD, "blacklist", "Either 'blacklist' or 'whitelist'");
-        worldGen_Generate_Lead_dimensions = ConfigHelper.getIntegerList(configuration, "Dimensions", WORLDGEN_ORES_LEAD, dimBlacklist, "Dimension Numbers");
+            oreConfig.Enabled = ConfigHelper.getBoolean(configuration, oreName, WORLDGEN_ORES, defaultConfig.Enabled, String.format(DESC_ENABLED, oreLower));
 
-        worldGen_Generate_Nickel_minY = ConfigHelper.getInteger(configuration, "Min Height", WORLDGEN_ORES_NICKEL, 5, "Min Y level nickel will spawn at");
-        worldGen_Generate_Nickel_maxY = ConfigHelper.getInteger(configuration, "Max Height", WORLDGEN_ORES_NICKEL, 60, "Max Y level nickel will spawn at");
-        worldGen_Generate_Nickel_veinSize = ConfigHelper.getInteger(configuration, "Vein Size", WORLDGEN_ORES_NICKEL, 4, "Size of vein");
-        worldGen_Generate_Nickel_weight = ConfigHelper.getInteger(configuration, "Weight", WORLDGEN_ORES_NICKEL, 20, "Percent chance that nickel will generate in chunk");
-        worldGen_Generate_Nickel_chunkOccurrence = ConfigHelper.getInteger(configuration, "Chunk Occurrence", WORLDGEN_ORES_NICKEL, 20, "Number of times nickel will attempt to generate in a chunk");
-        worldGen_Generate_Nickel_dimensionRestriction = ConfigHelper.getString(configuration, "Dimension Restriction", WORLDGEN_ORES_NICKEL, "blacklist", "Either 'blacklist' or 'whitelist'");
-        worldGen_Generate_Nickel_dimensions = ConfigHelper.getIntegerList(configuration, "Dimensions", WORLDGEN_ORES_NICKEL, dimBlacklist, "Dimension Numbers");
+            oreConfig.MinY = ConfigHelper.getInteger(configuration, "Min Height", category, defaultConfig.MinY, String.format(DESC_MIN_Y, oreLower));
+            oreConfig.MaxY = ConfigHelper.getInteger(configuration, "Max Height", category, defaultConfig.MaxY, String.format(DESC_MAX_Y, oreLower));
+            oreConfig.VeinSize = ConfigHelper.getInteger(configuration, "Vein Size", category, defaultConfig.VeinSize, String.format(DESC_VEIN_SIZE, oreLower));
+            oreConfig.Weight = ConfigHelper.getInteger(configuration, "Weight", category, defaultConfig.Weight, String.format(DESC_WEIGHT, oreLower));
+            oreConfig.ChunkOccurrence = ConfigHelper.getInteger(configuration, "Chunk Occurrence", category, defaultConfig.ChunkOccurrence, String.format(DESC_CHUNK_OCCURRENCE, oreLower));
 
-        worldGen_Generate_Rutile_minY = ConfigHelper.getInteger(configuration, "Min Height", WORLDGEN_ORES_RUTILE, 1, "Min Y level rutile will spawn at");
-        worldGen_Generate_Rutile_maxY = ConfigHelper.getInteger(configuration, "Max Height", WORLDGEN_ORES_RUTILE, 75, "Max Y level rutile will spawn at");
-        worldGen_Generate_Rutile_veinSize = ConfigHelper.getInteger(configuration, "Vein Size", WORLDGEN_ORES_RUTILE, 20, "Size of vein");
-        worldGen_Generate_Rutile_weight = ConfigHelper.getInteger(configuration, "Weight", WORLDGEN_ORES_RUTILE, 30, "Percent chance that rutile will generate in chunk");
-        worldGen_Generate_Rutile_chunkOccurrence = ConfigHelper.getInteger(configuration, "Chunk Occurrence", WORLDGEN_ORES_RUTILE, 20, "Number of times rutile will attempt to generate in a chunk");
-        worldGen_Generate_Rutile_dimensionRestriction = ConfigHelper.getString(configuration, "Dimension Restriction", WORLDGEN_ORES_RUTILE, "blacklist", "Either 'blacklist' or 'whitelist'");
-        worldGen_Generate_Rutile_dimensions = ConfigHelper.getIntegerList(configuration, "Dimensions", WORLDGEN_ORES_RUTILE, dimBlacklist, "Dimension Numbers");
+            String defaultDimRestriction = defaultConfig.DimensionRestriction.name().toLowerCase();
+            String dimRestriction = ConfigHelper.getString(configuration, "Dimension Restriction", category, defaultDimRestriction, DESC_DIM_RESTRICTION);
+            oreConfig.DimensionRestriction = RestrictionType.fromString(dimRestriction, defaultConfig.DimensionRestriction);
+
+            oreConfig.Dimensions = ConfigHelper.getIntegerList(configuration, "Dimensions", category, defaultConfig.Dimensions, DESC_DIM_LIST);
+
+            OreWorldGen.put(ore, oreConfig);
+        }
     }
 }

--- a/src/main/java/tech/flatstone/appliedlogistics/common/util/EnumOres.java
+++ b/src/main/java/tech/flatstone/appliedlogistics/common/util/EnumOres.java
@@ -23,7 +23,9 @@ package tech.flatstone.appliedlogistics.common.util;
 import net.minecraft.util.IStringSerializable;
 import tech.flatstone.appliedlogistics.api.features.EnumOreType;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public enum EnumOres implements IStringSerializable {
     // Vanilla Ores
@@ -59,12 +61,12 @@ public enum EnumOres implements IStringSerializable {
 
     private final String name;
     private final int meta;
-    private final EnumOreType[] enumOresTypelist;
+    private final EnumOreType[] enumOresTypeList;
 
     EnumOres(String name, int meta, EnumOreType... oreTypes) {
         this.name = name;
         this.meta = meta;
-        this.enumOresTypelist = oreTypes;
+        this.enumOresTypeList = oreTypes;
     }
 
     public static EnumOres byMeta(int meta) {
@@ -73,6 +75,18 @@ public enum EnumOres implements IStringSerializable {
         }
 
         return META_LOOKUP[meta];
+    }
+
+    public static List<EnumOres> byType(EnumOreType type) {
+        List<EnumOres> result = new ArrayList<>();
+
+        for (EnumOres ore : values()) {
+            if (ore.isTypeSet(type)) {
+                result.add(ore);
+            }
+        }
+
+        return result;
     }
 
     public int getMeta() {
@@ -92,6 +106,6 @@ public enum EnumOres implements IStringSerializable {
     }
 
     public boolean isTypeSet(EnumOreType enumOreType) {
-        return Arrays.asList(enumOresTypelist).contains(enumOreType);
+        return Arrays.asList(enumOresTypeList).contains(enumOreType);
     }
 }

--- a/src/main/java/tech/flatstone/appliedlogistics/common/world/WorldGen.java
+++ b/src/main/java/tech/flatstone/appliedlogistics/common/world/WorldGen.java
@@ -147,7 +147,7 @@ public class WorldGen implements IWorldGenerator {
         }
 
         public void generate(World world, Random random, int x, int z) {
-            if (oreConfig.isEnabledForDim(world.provider.getDimensionId())) {
+            if (oreConfig.Enabled && oreConfig.isEnabledForDim(world.provider.getDimensionId())) {
                 for (int i = 0; i < oreConfig.ChunkOccurrence; i++) {
                     if (random.nextInt(100) < oreConfig.Weight) {
                         BlockPos blockPos = new BlockPos(x + random.nextInt(16), oreConfig.MinY + random.nextInt(oreConfig.MaxY - oreConfig.MinY), z + random.nextInt(16));

--- a/src/main/java/tech/flatstone/appliedlogistics/common/world/WorldGen.java
+++ b/src/main/java/tech/flatstone/appliedlogistics/common/world/WorldGen.java
@@ -36,6 +36,7 @@ import net.minecraftforge.fml.common.IWorldGenerator;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.relauncher.Side;
+import tech.flatstone.appliedlogistics.common.config.ConfigWorldGen;
 import tech.flatstone.appliedlogistics.common.util.LogHelper;
 import tech.flatstone.appliedlogistics.common.util.WorldInfoHelper;
 
@@ -44,30 +45,25 @@ import java.util.List;
 import java.util.Random;
 
 public class WorldGen implements IWorldGenerator {
-    private static ArrayList<OreGen> oreSpawnList = new ArrayList();
-    private static ArrayList<Integer> oreDimBlackList = new ArrayList();
+    private static List<OreGen> oreSpawnList = new ArrayList<>();
     private static ArrayListMultimap<Integer, ChunkCoordIntPair> retrogenChunks = ArrayListMultimap.create();
     private int numChunks = 2;
 
-    public static OreGen addOreGen(String name, IBlockState block, int maxVeinSize, int minY, int maxY, int chunkOccurrence, int weight) {
-        OreGen oreGen = new OreGen(name, block, maxVeinSize, Blocks.stone, minY, maxY, chunkOccurrence, weight);
+    public static OreGen addOreGen(String name, IBlockState block, ConfigWorldGen.OreConfig oreConfig) {
+        OreGen oreGen = new OreGen(name, block, Blocks.stone, oreConfig);
         oreSpawnList.add(oreGen);
         return oreGen;
     }
 
     @Override
     public void generate(Random random, int chunkX, int chunkZ, World world, IChunkProvider chunkGenerator, IChunkProvider chunkProvider) {
-        if (!oreDimBlackList.contains(world.provider.getDimensionId()))
-            for (OreGen oreGen : oreSpawnList)
-                oreGen.generate(world, random, chunkX * 16, chunkZ * 16);
+        generateOres(random, chunkX, chunkZ, world, true);
     }
 
     public void generateOres(Random random, int chunkX, int chunkZ, World world, boolean newGeneration) {
-        if (!oreDimBlackList.contains(world.provider.getDimensionId())) {
-            for (OreGen gen : oreSpawnList) {
-                if ((newGeneration) || (retroGenEnabled(gen.name))) {
-                    gen.generate(world, random, chunkX * 16, chunkZ * 16);
-                }
+        for (OreGen gen : oreSpawnList) {
+            if ((newGeneration) || (retroGenEnabled(gen.name))) {
+                gen.generate(world, random, chunkX * 16, chunkZ * 16);
             }
         }
     }
@@ -140,27 +136,23 @@ public class WorldGen implements IWorldGenerator {
     }
 
     public static class OreGen {
-        WorldGenMinable worldGenMinable;
-        int minY;
-        int maxY;
-        int chunkOccurrence;
-        int weight;
         String name;
+        WorldGenMinable worldGenMinable;
+        ConfigWorldGen.OreConfig oreConfig;
 
-        public OreGen(String name, IBlockState block, int maxVeinSize, Block replaceTarget, int minY, int maxY, int chunkOccurrence, int weight) {
+        public OreGen(String name, IBlockState block, Block replaceTarget, ConfigWorldGen.OreConfig oreConfig) {
             this.name = name;
-            this.worldGenMinable = new WorldGenMinable(block, maxVeinSize, BlockHelper.forBlock(replaceTarget));
-            this.minY = minY;
-            this.maxY = maxY;
-            this.chunkOccurrence = chunkOccurrence;
-            this.weight = weight;
+            this.worldGenMinable = new WorldGenMinable(block, oreConfig.VeinSize, BlockHelper.forBlock(replaceTarget));
+            this.oreConfig = oreConfig;
         }
 
         public void generate(World world, Random random, int x, int z) {
-            for (int i = 0; i < chunkOccurrence; i++) {
-                if (random.nextInt(100) < this.weight) {
-                    BlockPos blockPos = new BlockPos(x + random.nextInt(16), this.minY + random.nextInt(this.maxY - this.minY), z + random.nextInt(16));
-                    this.worldGenMinable.generate(world, random, blockPos);
+            if (oreConfig.isEnabledForDim(world.provider.getDimensionId())) {
+                for (int i = 0; i < oreConfig.ChunkOccurrence; i++) {
+                    if (random.nextInt(100) < oreConfig.Weight) {
+                        BlockPos blockPos = new BlockPos(x + random.nextInt(16), oreConfig.MinY + random.nextInt(oreConfig.MaxY - oreConfig.MinY), z + random.nextInt(16));
+                        this.worldGenMinable.generate(world, random, blockPos);
+                    }
                 }
             }
         }

--- a/src/main/java/tech/flatstone/appliedlogistics/common/world/WorldGenInit.java
+++ b/src/main/java/tech/flatstone/appliedlogistics/common/world/WorldGenInit.java
@@ -8,10 +8,9 @@ import tech.flatstone.appliedlogistics.common.util.EnumOres;
 public class WorldGenInit {
     public static void init() {
         for (EnumOres ore : EnumOres.byType(EnumOreType.ORE)) {
+            // Always add ores, in case they get enabled at runtime
             ConfigWorldGen.OreConfig config = ConfigWorldGen.OreWorldGen.get(ore);
-            if (config.Enabled) {
-                WorldGen.addOreGen(ore.getName(), Blocks.BLOCK_ORE.getBlock().getStateFromMeta(ore.getMeta()), config);
-            }
+            WorldGen.addOreGen(ore.getName(), Blocks.BLOCK_ORE.getBlock().getStateFromMeta(ore.getMeta()), config);
         }
     }
 }

--- a/src/main/java/tech/flatstone/appliedlogistics/common/world/WorldGenInit.java
+++ b/src/main/java/tech/flatstone/appliedlogistics/common/world/WorldGenInit.java
@@ -1,47 +1,16 @@
 package tech.flatstone.appliedlogistics.common.world;
 
-import net.minecraft.block.state.IBlockState;
-import net.minecraftforge.fml.relauncher.ReflectionHelper;
-import org.apache.commons.lang3.text.WordUtils;
 import tech.flatstone.appliedlogistics.api.features.EnumOreType;
 import tech.flatstone.appliedlogistics.common.blocks.Blocks;
-import tech.flatstone.appliedlogistics.common.config.Config;
 import tech.flatstone.appliedlogistics.common.config.ConfigWorldGen;
 import tech.flatstone.appliedlogistics.common.util.EnumOres;
-import tech.flatstone.appliedlogistics.common.util.LogHelper;
-
-import java.lang.reflect.Field;
 
 public class WorldGenInit {
-    private static void addConfiguredWorldGen(IBlockState state, String blockName) {
-        String blockConfigName = WordUtils.capitalize(blockName);
-
-        try {
-            boolean enabled = ReflectionHelper.findField(ConfigWorldGen.class, String.format("worldGen_Generate_%s", blockConfigName)).getBoolean(ConfigWorldGen.class);
-            int minY = ReflectionHelper.findField(ConfigWorldGen.class, String.format("worldGen_Generate_%s_minY", blockConfigName)).getInt(ConfigWorldGen.class);
-            int maxY = ReflectionHelper.findField(ConfigWorldGen.class, String.format("worldGen_Generate_%s_maxY", blockConfigName)).getInt(ConfigWorldGen.class);;
-            int veinSize = ReflectionHelper.findField(ConfigWorldGen.class, String.format("worldGen_Generate_%s_veinSize", blockConfigName)).getInt(ConfigWorldGen.class);;
-            int weight = ReflectionHelper.findField(ConfigWorldGen.class, String.format("worldGen_Generate_%s_weight", blockConfigName)).getInt(ConfigWorldGen.class);;
-            int chunkOccurrence = ReflectionHelper.findField(ConfigWorldGen.class, String.format("worldGen_Generate_%s_chunkOccurrence", blockConfigName)).getInt(ConfigWorldGen.class);;
-            String dimensionRestriction = (String)ReflectionHelper.findField(ConfigWorldGen.class, String.format("worldGen_Generate_%s_dimensionRestriction", blockConfigName)).get(ConfigWorldGen.class);;
-            int[] dimensions = (int[])ReflectionHelper.findField(ConfigWorldGen.class, String.format("worldGen_Generate_%s_dimensions", blockConfigName)).get(ConfigWorldGen.class);;
-
-            if (enabled)
-                WorldGen.addOreGen(blockName, state, veinSize, minY, maxY, chunkOccurrence, weight);
-
-        } catch (IllegalAccessException ex) {
-            LogHelper.fatal("There was a fatal exception with setting up worldGen");
-            ex.printStackTrace();
-        } catch (ClassCastException ex) {
-            LogHelper.fatal("Failed to get proper config type, erase your config and relaunch minecraft");
-            ex.printStackTrace();
-        }
-    }
-
     public static void init() {
-        for (int i = 0; i < EnumOres.values().length; i++) {
-            if (EnumOres.byMeta(i).isTypeSet(EnumOreType.ORE)) {
-                addConfiguredWorldGen(Blocks.BLOCK_ORE.getBlock().getStateFromMeta(i), EnumOres.byMeta(i).getUnlocalizedName());
+        for (EnumOres ore : EnumOres.byType(EnumOreType.ORE)) {
+            ConfigWorldGen.OreConfig config = ConfigWorldGen.OreWorldGen.get(ore);
+            if (config.Enabled) {
+                WorldGen.addOreGen(ore.getName(), Blocks.BLOCK_ORE.getBlock().getStateFromMeta(ore.getMeta()), config);
             }
         }
     }


### PR DESCRIPTION
Load ore worldgen config into a structure instead of individual variables, so we can iterate over ores and eliminate the use of reflection to read the config. Also put in dimension restriction checks.