### PR TITLE
Fixed crank ray tracing bugs.

### DIFF
--- a/src/main/java/tech/flatstone/appliedlogistics/common/blocks/misc/BlockCrank.java
+++ b/src/main/java/tech/flatstone/appliedlogistics/common/blocks/misc/BlockCrank.java
@@ -198,13 +198,11 @@ public class BlockCrank extends BlockTileBase implements IProvideRecipe, IProvid
             distance = start.distanceTo(crankTopPos.hitVec);
         }
 
-        if (crankShaftPos != null && start.distanceTo(crankShaftPos.hitVec) < distance)
-        {
+        if (crankShaftPos != null && start.distanceTo(crankShaftPos.hitVec) < distance) {
             lookObject = crankShaftPos;
         }
-        
-        if (lookObject != null)
-        {
+ 
+        if (lookObject != null) {
             return new RayTraceResult(lookObject.hitVec.addVector(pos.getX(), pos.getY(), pos.getZ()), lookObject.sideHit, pos);
         }
 

--- a/src/main/java/tech/flatstone/appliedlogistics/common/blocks/misc/BlockCrank.java
+++ b/src/main/java/tech/flatstone/appliedlogistics/common/blocks/misc/BlockCrank.java
@@ -190,12 +190,23 @@ public class BlockCrank extends BlockTileBase implements IProvideRecipe, IProvid
         RayTraceResult crankTopPos = crankTop.calculateIntercept(start, end);
         RayTraceResult crankShaftPos = crankShaft.calculateIntercept(start, end);
 
+        RayTraceResult lookObject = null;
+        double distance = Double.MAX_VALUE;
+
         if (crankTopPos != null) {
-            return new RayTraceResult(start.addVector((double) pos.getX(), (double) pos.getY(), (double) pos.getZ()), crankTopPos.sideHit, pos);
+            lookObject = crankTopPos;
+            distance = start.distanceTo(crankTopPos.hitVec);
         }
 
-        if (crankShaftPos != null)
-            return new RayTraceResult(start.addVector((double) pos.getX(), (double) pos.getY(), (double) pos.getZ()), crankShaftPos.sideHit, pos);
+        if (crankShaftPos != null && start.distanceTo(crankShaftPos.hitVec) < distance)
+        {
+            lookObject = crankShaftPos;
+        }
+        
+        if (lookObject != null)
+        {
+            return new RayTraceResult(lookObject.hitVec.addVector(pos.getX(), pos.getY(), pos.getZ()), lookObject.sideHit, pos);
+        }
 
         return null;
     }

--- a/src/main/java/tech/flatstone/appliedlogistics/common/blocks/misc/BlockCrank.java
+++ b/src/main/java/tech/flatstone/appliedlogistics/common/blocks/misc/BlockCrank.java
@@ -183,9 +183,9 @@ public class BlockCrank extends BlockTileBase implements IProvideRecipe, IProvid
         EnumFacing crankRotation = tileEntity.getCrankRotation();
 
         AxisAlignedBB crankTop = new AxisAlignedBB(7 / 16d, 10 / 16d, 2 / 16d, 9 / 16d, 12 / 16d, 14 / 16d);
-        AxisAlignedBB crankShaft = new AxisAlignedBB(7 / 16d, 0, 7 / 16d, 9 / 16d, 10 / 16d, 9 / 16d).offset(pos.getX(), pos.getY(), pos.getZ());
+        AxisAlignedBB crankShaft = new AxisAlignedBB(7 / 16d, 0, 7 / 16d, 9 / 16d, 10 / 16d, 9 / 16d).offset(pos);
 
-        crankTop = RotationHelper.rotateBB(crankTop, crankRotation).offset(pos.getX(), pos.getY(), pos.getZ());
+        crankTop = RotationHelper.rotateBB(crankTop, crankRotation).offset(pos);
 
         RayTraceResult crankTopPos = crankTop.calculateIntercept(start, end);
         RayTraceResult crankShaftPos = crankShaft.calculateIntercept(start, end);
@@ -313,9 +313,9 @@ public class BlockCrank extends BlockTileBase implements IProvideRecipe, IProvid
         EnumFacing crankRotation = tileEntity.getCrankRotation();
 
         AxisAlignedBB crankTop = new AxisAlignedBB(7 / 16d, 10 / 16d, 2 / 16d, 9 / 16d, 12 / 16d, 14 / 16d);
-        AxisAlignedBB crankShaft = new AxisAlignedBB(7 / 16d, 0, 7 / 16d, 9 / 16d, 10 / 16d, 9 / 16d).offset(pos.getX(), pos.getY(), pos.getZ());
+        AxisAlignedBB crankShaft = new AxisAlignedBB(7 / 16d, 0, 7 / 16d, 9 / 16d, 10 / 16d, 9 / 16d).offset(pos);
 
-        crankTop = RotationHelper.rotateBB(crankTop, crankRotation).offset(pos.getX(), pos.getY(), pos.getZ());
+        crankTop = RotationHelper.rotateBB(crankTop, crankRotation).offset(pos);
 
         if (mask != null && crankTop.intersectsWith(mask))
             list.add(crankTop);
@@ -337,9 +337,9 @@ public class BlockCrank extends BlockTileBase implements IProvideRecipe, IProvid
         EnumFacing crankRotation = tileEntity.getCrankRotation();
 
         AxisAlignedBB crankTop = new AxisAlignedBB(7 / 16d, 10 / 16d, 2 / 16d, 9 / 16d, 12 / 16d, 14 / 16d);
-        AxisAlignedBB crankShaft = new AxisAlignedBB(7 / 16d, 0, 7 / 16d, 9 / 16d, 10 / 16d, 9 / 16d).offset(pos.getX(), pos.getY(), pos.getZ());
+        AxisAlignedBB crankShaft = new AxisAlignedBB(7 / 16d, 0, 7 / 16d, 9 / 16d, 10 / 16d, 9 / 16d).offset(pos);
 
-        crankTop = RotationHelper.rotateBB(crankTop, crankRotation).offset(pos.getX(), pos.getY(), pos.getZ());
+        crankTop = RotationHelper.rotateBB(crankTop, crankRotation).offset(pos);
 
         int stateID = Block.getStateId(getDefaultState().getActualState(world, pos));
         double i = 9;


### PR DESCRIPTION
Fixed crank ray tracing bugs: 1) return hitVec was being set to eye pos, rather than the ray trace result hitVec; 2) the first object intersecting the ray is returned, rather than considering all objects and returning the one with the hitVec closest to the eye pos.